### PR TITLE
feat: add markdown formatting toolbar and improve link styling in news system

### DIFF
--- a/app/(mgmt)/[lang]/news/components/markdown-toolbar.tsx
+++ b/app/(mgmt)/[lang]/news/components/markdown-toolbar.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Bold, Italic, Heading2, Link as LinkIcon, List, ListOrdered, Code } from 'lucide-react';
+import { RefObject } from 'react';
+
+interface MarkdownToolbarProps {
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+}
+
+export function MarkdownToolbar({ textareaRef }: MarkdownToolbarProps) {
+  const insertMarkdown = (before: string, after: string = '', placeholder: string = '') => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const text = textarea.value;
+    const selectedText = text.substring(start, end);
+
+    const insertText = selectedText || placeholder;
+    const newText = text.substring(0, start) + before + insertText + after + text.substring(end);
+
+    textarea.value = newText;
+
+    // Trigger onChange event for React Hook Form
+    const event = new Event('input', { bubbles: true });
+    textarea.dispatchEvent(event);
+
+    // Set cursor position
+    const newCursorPos = selectedText
+      ? start + before.length + insertText.length + after.length
+      : start + before.length;
+    textarea.setSelectionRange(newCursorPos, newCursorPos);
+    textarea.focus();
+  };
+
+  const buttons = [
+    {
+      icon: Bold,
+      label: 'Bold',
+      tooltip: 'Bold (Ctrl+B)',
+      action: () => insertMarkdown('**', '**', 'bold text'),
+    },
+    {
+      icon: Italic,
+      label: 'Italic',
+      tooltip: 'Italic (Ctrl+I)',
+      action: () => insertMarkdown('*', '*', 'italic text'),
+    },
+    {
+      icon: Heading2,
+      label: 'Heading',
+      tooltip: 'Heading',
+      action: () => insertMarkdown('## ', '', 'Heading'),
+    },
+    {
+      icon: LinkIcon,
+      label: 'Link',
+      tooltip: 'Insert Link',
+      action: () => insertMarkdown('[', '](url)', 'link text'),
+    },
+    {
+      icon: List,
+      label: 'Bullet List',
+      tooltip: 'Bullet List',
+      action: () => insertMarkdown('- ', '', 'list item'),
+    },
+    {
+      icon: ListOrdered,
+      label: 'Numbered List',
+      tooltip: 'Numbered List',
+      action: () => insertMarkdown('1. ', '', 'list item'),
+    },
+    {
+      icon: Code,
+      label: 'Code',
+      tooltip: 'Inline Code',
+      action: () => insertMarkdown('`', '`', 'code'),
+    },
+  ];
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className='flex items-center gap-1 rounded-md border bg-muted/30 p-1'>
+        {buttons.map((button, index) => (
+          <div key={button.label} className='flex items-center'>
+            {index === 3 && <Separator orientation='vertical' className='mx-1 h-6' />}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon'
+                  className='h-8 w-8'
+                  onClick={button.action}
+                >
+                  <button.icon className='h-4 w-4' />
+                  <span className='sr-only'>{button.label}</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{button.tooltip}</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        ))}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/app/(mgmt)/[lang]/news/components/news-form.tsx
+++ b/app/(mgmt)/[lang]/news/components/news-form.tsx
@@ -9,13 +9,14 @@ import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useState } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import * as z from 'zod';
 import { createNews, updateNews, redirectToHome } from '../actions';
 import { NewsType } from '../lib/types';
 import { Plus, Loader2 } from 'lucide-react';
+import { MarkdownToolbar } from './markdown-toolbar';
 
 interface NewsFormProps {
   news?: NewsType;
@@ -25,7 +26,8 @@ interface NewsFormProps {
 
 export default function NewsForm({ news, lang, dict }: NewsFormProps) {
   const [isPending, setIsPending] = useState(false);
-  
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
   const newsSchema = createNewsSchema(dict.news.validation);
   
   const form = useForm<z.infer<typeof newsSchema>>({
@@ -92,19 +94,30 @@ export default function NewsForm({ news, lang, dict }: NewsFormProps) {
             <FormField
               control={form.control}
               name='content'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{dict.news.form.contentLabel}</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      placeholder={dict.news.form.contentPlaceholder}
-                      className="min-h-[300px]"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
+              render={({ field }) => {
+                const { ref: fieldRef, ...fieldProps } = field;
+                return (
+                  <FormItem>
+                    <FormLabel>{dict.news.form.contentLabel}</FormLabel>
+                    <MarkdownToolbar textareaRef={textareaRef} />
+                    <FormControl>
+                      <Textarea
+                        placeholder={dict.news.form.contentPlaceholder}
+                        className="min-h-[300px]"
+                        ref={(e) => {
+                          fieldRef(e);
+                          textareaRef.current = e;
+                        }}
+                        {...fieldProps}
+                      />
+                    </FormControl>
+                    <p className="text-xs text-muted-foreground">
+                      Markdown formatting supported
+                    </p>
+                    <FormMessage />
+                  </FormItem>
+                );
+              }}
             />
             
             <FormField

--- a/app/globals.css
+++ b/app/globals.css
@@ -242,9 +242,42 @@
   font-weight: 600;
 }
 
+.prose a {
+  color: oklch(0.72 0.13 124.79);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 0.2s ease-in-out;
+}
+
+.prose a:hover {
+  color: oklch(0.62 0.13 124.79);
+}
+
+.prose code {
+  background-color: oklch(0.95 0 0);
+  color: oklch(0.2 0 0);
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  font-size: 0.875em;
+  font-weight: 500;
+}
+
 /* Dark mode adjustments */
 .dark .prose {
   color: var(--foreground);
+}
+
+.dark .prose a {
+  color: oklch(0.72 0.13 124.79);
+}
+
+.dark .prose a:hover {
+  color: oklch(0.82 0.13 124.79);
+}
+
+.dark .prose code {
+  background-color: oklch(0.27 0 0);
+  color: oklch(0.99 0 0);
 }
 
 .dark .prose h1,


### PR DESCRIPTION
## Summary

- Added **MarkdownToolbar** component with formatting buttons (Bold, Italic, Heading, Link, Lists, Code)
- Improved markdown link styling with primary color, underline, and hover effects
- Added inline code styling for better readability in news content
- Full support for light and dark mode
- English-only labels (no i18n overhead)

## Changes

### New Component
- `markdown-toolbar.tsx` - Reusable toolbar with 7 formatting buttons and tooltips

### Style Improvements
- `.prose a` - Links now visible with primary color and underline
- `.prose code` - Inline code with background and proper spacing
- Dark mode variants for all markdown elements

### Form Integration
- Toolbar integrated above textarea in news form
- Callback ref pattern for proper React Hook Form integration
- Visual hint "Markdown formatting supported"

## Test plan

- [x] Build passes without errors
- [ ] Create/edit news with formatting buttons
- [ ] Verify link styling on homepage
- [ ] Test in both light and dark mode
- [ ] Verify tooltips appear on button hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)